### PR TITLE
[Bug] 페이지 이동 시 스크롤 위치 맨 위로 설정하는 ScrollToTop 컴포넌트 작성 및 적용

### DIFF
--- a/src/components/layouts/ScrollToTop.tsx
+++ b/src/components/layouts/ScrollToTop.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
+
+const ScrollToTop = () => {
+  const { pathname } = useLocation()
+
+  useEffect(() => {
+    window.scrollTo(0, 0)
+  }, [pathname])
+
+  return <div></div>
+}
+
+export default ScrollToTop

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,12 +7,14 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { globalStyle } from '@styles/theme/global'
 import { theme } from '@styles/index'
+import ScrollToTop from '@components/layouts/ScrollToTop'
 
 const queryClient = new QueryClient()
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <BrowserRouter basename="/">
     <Global styles={globalStyle} />
+    <ScrollToTop />
     <ThemeProvider theme={theme}>
       <RecoilRoot>
         <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
## Related Issues
<!-- - close 뒤에 이슈 달아주기 -->
- close #153 
## Describe your changes
<!-- 스크린샷 및 작업내용을 적어주세요 -->
프로필 페이지에서 프로필 수정 페이지로 가면 스크롤 위치가 이전 페이지랑 동일한 것을 발견했습니다.
그래서 페이지 이동 시 스크롤 위치를 맨 위로 가도록 하는 ScrollToTop 컴포넌트를 작성했고, 적용해놨습니다.

## To Reviewers
<!-- 리뷰어에게 남기는 참고사항을 적어주세요 -->

