### PR TITLE
[Refac] 친구 리스트 가나다순 정렬

### DIFF
--- a/src/components/friends/AllFriends.tsx
+++ b/src/components/friends/AllFriends.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useEffect } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useRecoilValue } from 'recoil'
 import { FlexBox } from '@components/layouts/FlexBox'
@@ -29,6 +29,10 @@ const AllFriends = () => {
     ['friendsList', auth.userProfile.id],
     FriendsApi.GET_FRIENDS_LIST,
   )
+
+  useEffect(() => {
+    friendsList.sort((a, b) => a.neighborName.localeCompare(b.neighborName))
+  }, [friendsList])
 
   const getMenuIcon = useCallback(() => {
     if (isCubeList.value) {

--- a/src/components/friends/AllFriends.tsx
+++ b/src/components/friends/AllFriends.tsx
@@ -80,10 +80,10 @@ const AllFriends = () => {
         />
       </FlexBox>
       {friendsList.length ? (
-        <>
+        <div style={{ width: '100%' }}>
           <Padding size={[0, 16]}>{renderCubeFriendsList()}</Padding>
           <Spacing height={16} />
-        </>
+        </div>
       ) : (
         <>
           <Spacing height={32} />

--- a/src/components/friends/BirthdayFriends.tsx
+++ b/src/components/friends/BirthdayFriends.tsx
@@ -7,6 +7,7 @@ import { Text } from '@components/atoms/Text'
 import FriendsListBItem from './FriendsListBItem'
 import { authState } from '@libs/store/auth'
 import { FriendsApi } from '@utils/apis/friends/FriendsApi'
+import { useEffect } from 'react'
 
 const BirthdayFriends = () => {
   const auth = useRecoilValue(authState)
@@ -15,6 +16,12 @@ const BirthdayFriends = () => {
     ['birthdayFriendsList', auth.userProfile.id],
     FriendsApi.GET_BIRTHDAY_FRIENDS_LIST,
   )
+
+  useEffect(() => {
+    birthdayFriendsList.sort((a, b) =>
+      a.neighborName.localeCompare(b.neighborName),
+    )
+  }, [birthdayFriendsList])
 
   return birthdayFriendsList.length ? (
     <>

--- a/src/components/friends/NewFriends.tsx
+++ b/src/components/friends/NewFriends.tsx
@@ -8,6 +8,7 @@ import { useQuery } from '@tanstack/react-query'
 import { useRecoilValue } from 'recoil'
 import { authState } from '@libs/store/auth'
 import { FriendsApi } from '@utils/apis/friends/FriendsApi'
+import { useEffect } from 'react'
 
 const NewFriends = () => {
   const auth = useRecoilValue(authState)
@@ -16,6 +17,11 @@ const NewFriends = () => {
     ['newFriendsList', auth.userProfile.id],
     FriendsApi.GET_NEW_FRIENDS_LIST,
   )
+
+  useEffect(() => {
+    newFriendsList.sort((a, b) => a.neighborName.localeCompare(b.neighborName))
+  }, [newFriendsList])
+
   return newFriendsList.length ? (
     <>
       <FlexBox justify="flex-start" style={{ width: '100%', padding: '16px' }}>


### PR DESCRIPTION
## Related Issues
<!-- - close 뒤에 이슈 달아주기 -->
- close #166 
## Describe your changes
<!-- 스크린샷 및 작업내용을 적어주세요 -->
새로운 친구, 모든 친구, 생일인 친구 리스트에서 친구를 가나다순으로 정렬하도록 수정해서 올려놨습니다.

## To Reviewers
<!-- 리뷰어에게 남기는 참고사항을 적어주세요 -->

